### PR TITLE
refactor(redis)implement redis mock

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 
 	db := database.Connect(cfg.DatabaseURL)
-	redis, err := redis.NewClient(context.Background(), cfg.RedisURL)
+	redis, err := redis.NewClient(context.Background(), cfg.RedisURL, nil)
 
 	urlRepo := url.NewRepository(db)
 	urlService := url.NewService(urlRepo, redis, cfg.IDOffset)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-redis/redis/v8"
+	"github.com/go-redis/redismock/v8"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -191,22 +192,33 @@ func TestFetchLongURL(t *testing.T) {
 func TestHealthCheck(t *testing.T) {
 	testcases := []struct {
 		name               string
-		dbShouldFail       bool
-		redisShouldFail    bool
+		setupMockDb       func(*mockDB)
+		setupMockRedis    func(redismock.ClientMock)
 		expectedStatusCode int
 		expectedBody       string
 	}{
 		{
 			name:               "db fails, redis succeeds",
-			dbShouldFail:       true,
-			redisShouldFail:    false,
+			setupMockDb: func(db *mockDB) {
+				db.ShouldFail  = true
+			},
+			setupMockRedis: func(redis redismock.ClientMock) {
+
+
+			},
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody:       "Database not connected",
 		},
 		{
 			name:               "db succeeds, redis fails",
-			dbShouldFail:       false,
-			redisShouldFail:    true,
+			setupMockDb: func(db *mockDB) {
+				db.ShouldFail = false
+
+			},
+			setupMockRedis: func(redis redismock.ClientMock) {
+				redis.ExpectPing().SetErr(errors.New("mock redis error"))
+
+			},
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody:       "Redis not connected",
 		},
@@ -214,21 +226,22 @@ func TestHealthCheck(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			server := &Server{
-				db: &mockDB{
-					ShouldFail: tc.dbShouldFail,
-				},
-				redis: &mockRedis{
-					ShouldFail: tc.redisShouldFail,
-				},
-			}
+			db := &mockDB{}
+			tc.setupMockDb(db)
 
+			redis, mockRedis := redismock.NewClientMock()
+			tc.setupMockRedis(mockRedis)
+
+			server := &Server{
+				db: db,
+				redis: redis,
+			}
 			req, _ := http.NewRequest(http.MethodGet, "/api/v1/health", nil)
 			rr := httptest.NewRecorder()
 
 			server.healthCheckHandler(rr, req)
 
-			assert.Equal(t, tc.expectedStatusCode, rr.Code)
+			assert.Equal(t, rr.Code, tc.expectedStatusCode)
 			assert.Contains(t, rr.Body.String(), tc.expectedBody)
 		})
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -192,25 +192,24 @@ func TestFetchLongURL(t *testing.T) {
 func TestHealthCheck(t *testing.T) {
 	testcases := []struct {
 		name               string
-		setupMockDb       func(*mockDB)
-		setupMockRedis    func(redismock.ClientMock)
+		setupMockDb        func(*mockDB)
+		setupMockRedis     func(redismock.ClientMock)
 		expectedStatusCode int
 		expectedBody       string
 	}{
 		{
-			name:               "db fails, redis succeeds",
+			name: "db fails, redis succeeds",
 			setupMockDb: func(db *mockDB) {
-				db.ShouldFail  = true
+				db.ShouldFail = true
 			},
 			setupMockRedis: func(redis redismock.ClientMock) {
-
 
 			},
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody:       "Database not connected",
 		},
 		{
-			name:               "db succeeds, redis fails",
+			name: "db succeeds, redis fails",
 			setupMockDb: func(db *mockDB) {
 				db.ShouldFail = false
 
@@ -233,7 +232,7 @@ func TestHealthCheck(t *testing.T) {
 			tc.setupMockRedis(mockRedis)
 
 			server := &Server{
-				db: db,
+				db:    db,
 				redis: redis,
 			}
 			req, _ := http.NewRequest(http.MethodGet, "/api/v1/health", nil)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -4,15 +4,16 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-redis/redis/v8"
 )
 
 type Server struct {
 	db         DB
-	redis      Redis
+	redis      *redis.Client
 	urlService URLService
 }
 
-func NewServer(db DB, redis Redis, urlService URLService) *Server {
+func NewServer(db DB, redis *redis.Client, urlService URLService) *Server {
 	return &Server{db: db, redis: redis, urlService: urlService}
 }
 

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -7,11 +7,14 @@ import (
 	"github.com/go-redis/redis/v8"
 )
 
-func NewClient(ctx context.Context, connStr string) (*redis.Client, error) {
+func NewClient(ctx context.Context, connStr string, opt *redis.Options) (*redis.Client, error) {
+	if opt == nil {
+		opt = &redis.Options{
+			Addr: connStr,
+		}
+	}
 
-	rdb := redis.NewClient(&redis.Options{
-		Addr: connStr,
-	})
+	rdb := redis.NewClient(opt)
 
 	if err := rdb.Ping(ctx).Err(); err != nil {
 		return nil, err

--- a/internal/redis/redis_test.go
+++ b/internal/redis/redis_test.go
@@ -20,10 +20,15 @@ func TestMain(m *testing.M) {
 
 	redisURL := os.Getenv("REDIS_URL_TEST")
 	if redisURL == "" {
-		redisURL = "localhost:6379/1" // DB 1 will be used as test database
+		redisURL = "redis://localhost:6379/1" // DB 1 will be used as test database
 	}
 
-	redisClient, err = NewClient(context.Background(), redisURL)
+	opt, err := redis.ParseURL(redisURL)
+	if err != nil {
+		log.Fatalf("FATAL: unable to parse Redis URL: %v", err)
+	}
+
+	redisClient, err = NewClient(context.Background(), redisURL, opt)
 
 	if err != nil {
 		log.Fatalf("FATAL: unable to connect to Redis: %v", err)


### PR DESCRIPTION
- **refactor(redis): use redis mock instead of custom redis interface**
- **style: formatting with go fmt**

replacing our own custom redis mock with library redis mock for more robust testing
